### PR TITLE
Add Cleanup Ability + Partial Overhaul of Instructionals + Some Optimization

### DIFF
--- a/XmlMods/TemplatesAndExamples/CopyMe-ModXMLTemplate.xml
+++ b/XmlMods/TemplatesAndExamples/CopyMe-ModXMLTemplate.xml
@@ -1,19 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE xml>
 
-<ModData mod_name="NAME_OF_MOD" mod_author="AUTHOR_OF_MOD" mod_description="DESCRIPTION_OF_MOD">
+<ModData mod_name="NAME_OF_MOD"  mod_segment="DIVISION_OF_MOD_IF_ANY" mod_author="AUTHOR_OF_MOD" mod_description="DESCRIPTION_OF_MOD">
 
+	<!--  For cleaning up the old names of your mod, if you change it - ignore if this isn't the case -->
+	<CleanupOldModNames name="OldModNameCleanup">
+		<Objects>
+		
+			<Object Mod_Name="OLD_MOD_NAME_TO_DESTROY_ELEMENTS_FOR"/>
+			
+		</Objects>
+	</CleanupOldModNames>
+	
+	
 	<!-- Added to /Game/Levels/Class3/Mission_Mission0.xml -->
 	<MissionData>
-		<Objects name="NAME_Entities" mod_segment="SEGMENT_NAME" parent_tag="Objects">
+		<Objects name="NAME_Entities" mod_subsegment="SEGMENT_NAME" parent_tag="Objects">
+		
 			<Object Name="UNIQUE_NAME"/>
+			
 		</Objects>
 	</MissionData>
 	
 	<!-- Added to /Game/Libs/Prefabs/Facilities.xml -->
 	<FacilitiesData>
-		<Objects name="LOCATION_Objects" mod_segment="SEGMENT_NAME" parent_tag="ELEMENT_TYPE_TO_ADD_THIS_TO" parent_name="ELEMENT_NAME_TO_ADD_THIS_TO">
+		<Objects name="LOCATION_Objects" mod_subsegment="SEGMENT_NAME" 
+			parent_tag="ELEMENT_TYPE_TO_ADD_THIS_TO" parent_name="ELEMENT_NAME_TO_ADD_THIS_TO">
+		
 			<Object Type="Brush" Name="UNIQUE_NAME" />
+			
 		</Objects>
 	</FacilitiesData>
 	

--- a/XmlMods/TemplatesAndExamples/FortitudeMod - Bases - Savini.xml
+++ b/XmlMods/TemplatesAndExamples/FortitudeMod - Bases - Savini.xml
@@ -2,6 +2,10 @@
 <!DOCTYPE xml>
 <ModData mod_name="Fortitude_Mod-Bases-Savini" mod_author="phacops" mod_description="When moving into the Savini household, this adds barricades and blockades and walkways to the area">
 
+	<CleanupOldModNames>
+		<Object name="Fortitude_Mod"/>
+	</CleanupOldModNames>
+	
 	<MissionData>
 		<Objects name="Savini_Entities" mod_segment="Savini/Riverside" parent_tag="Objects">
 				<Entity Name="Fortitude_Rope1" Material="objects/props/mine/chaff" Pos="1534.6277,804.91797,96.5" EntityClass="RopeEntity" EntityId="113" EntityGuid="4F50789C2D816AB8">

--- a/XmlMods/TemplatesAndExamples/FortitudeMod - Bases - Savini.xml
+++ b/XmlMods/TemplatesAndExamples/FortitudeMod - Bases - Savini.xml
@@ -2,8 +2,11 @@
 <!DOCTYPE xml>
 <ModData mod_name="Fortitude_Mod-Bases-Savini" mod_author="phacops" mod_description="When moving into the Savini household, this adds barricades and blockades and walkways to the area">
 
-	<CleanupOldModNames>
-		<Object name="Fortitude_Mod"/>
+	<CleanupOldModNames name="OldModNameCleanup" description="Fill this with an Object per old mod name you need to cleanup; 
+		although it isn't mandatory, it's nice because changing your mod name could potentially break the files">
+		<Objects>
+			<Object name="Fortitude_Mod"/>
+		</Objects>
 	</CleanupOldModNames>
 	
 	<MissionData>

--- a/XmlMods/TemplatesAndExamples/FortitudeMod - Bases - Savini.xml
+++ b/XmlMods/TemplatesAndExamples/FortitudeMod - Bases - Savini.xml
@@ -1,16 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE xml>
-<ModData mod_name="Fortitude_Mod-Bases-Savini" mod_author="phacops" mod_description="When moving into the Savini household, this adds barricades and blockades and walkways to the area">
+<ModData mod_name="Fortitude_Mod" mod_segment="Bases - Savini/Riverside" mod_author="phacops" mod_description="When moving into the Savini household, this adds barricades and blockades and walkways to the area">
 
-	<CleanupOldModNames name="OldModNameCleanup" description="Fill this with an Object per old mod name you need to cleanup; 
-		although it isn't mandatory, it's nice because changing your mod name could potentially break the files">
-		<Objects>
-			<Object name="Fortitude_Mod"/>
-		</Objects>
-	</CleanupOldModNames>
-	
 	<MissionData>
-		<Objects name="Savini_Entities" mod_segment="Savini/Riverside" parent_tag="Objects">
+		<Objects name="Savini_Entities" mod_subsegment="Savini/Riverside" parent_tag="Objects">
 				<Entity Name="Fortitude_Rope1" Material="objects/props/mine/chaff" Pos="1534.6277,804.91797,96.5" EntityClass="RopeEntity" EntityId="113" EntityGuid="4F50789C2D816AB8">
 				 <Rope flags="55" radius="0.02" anchor_radius="0.1" num_seg="8" num_sides="4" texu="1" texv="10" ph_num_seg="16" ph_sub_vtxs="20" mass="-1" friction="2" friction_pull="2" wind="0,0,0" wind_var="0" air_resist="0" water_resist="0" joint_lim="0" max_force="0" tension="0.0049999999" maxTimeStep="0.02" minEnergy="0.0016" damping="0.2" gravity="0,0,-13">
 				  <Points>
@@ -75,7 +68,7 @@
 	
 	<FacilitiesData>
 		
-		<Objects name="Savini_Objects" mod_segment="Savini/Riverside" parent_tag="Prefab" parent_name="riverside.command_center">
+		<Objects name="Savini_Objects" mod_subsegment="Savini/Riverside" parent_tag="Prefab" parent_name="riverside.command_center">
 			<Object Type="Brush" Name="iron_balistraria49" Pos="-11,1.75,0.5" FloorNumber="-1" Rotate="0.9238795,0,0,-0.38268346" Scale="1.2,1.2,1.2" ColorRGB="16777215" MatLayersMask="0" Prefab="objects/Fortitude/iron_balistraria.cgf" NoCollision="0" OutdoorOnly="0" CastShadowMaps="1" RainOccluder="1" SupportSecondVisarea="0" Hideable="0" LodRatio="100" ViewDistRatio="100" MeshIntegrationType="0" NotTriangulate="0" AIRadius="-1" NoStaticDecals="0" NoAmnbShadowCaster="0" RecvWind="0" RndFlags="536870920"/>
 			<Object Type="Brush" Name="Fortbbq" Pos="-32.55127,2.2990112,1.5923843" FloorNumber="-1" Rotate="0.23150559,0.39396966,0.85687774,0.23864952" ColorRGB="16777215" MatLayersMask="0" Prefab="objects/decor/yard/gas_grill/gas_grill_boom.cgf" NoCollision="0" OutdoorOnly="0" CastShadowMaps="1" RainOccluder="1" SupportSecondVisarea="0" Hideable="0" LodRatio="100" ViewDistRatio="100" MeshIntegrationType="0" NotTriangulate="0" AIRadius="-1" NoStaticDecals="0" NoAmnbShadowCaster="0" RecvWind="0" RndFlags="536870920"/>
 			<Object Type="Brush" Name="proxy_module28" Pos="-33.875,-1.625,-2.875" FloorNumber="-1" Rotate="0.72537452,0,0,0.68835443" ColorRGB="16777215" MatLayersMask="0" Prefab="objects/Fortitude/proxy_module.cgf" NoCollision="0" OutdoorOnly="0" CastShadowMaps="1" RainOccluder="1" SupportSecondVisarea="0" Hideable="0" LodRatio="100" ViewDistRatio="100" MeshIntegrationType="0" NotTriangulate="0" AIRadius="-1" NoStaticDecals="0" NoAmnbShadowCaster="0" RecvWind="0" RndFlags="536870920"/>

--- a/XmlMods/TemplatesAndExamples/FortitudeMod - Bases - Snyder.xml
+++ b/XmlMods/TemplatesAndExamples/FortitudeMod - Bases - Snyder.xml
@@ -2,8 +2,11 @@
 <!DOCTYPE xml>
 <ModData mod_name="Fortitude_Mod-Bases-Snyder_Trucking_Warehouse" mod_author="phacops" mod_description="When moving into the Snyder Trucking Warehouse, this adds barricades and blockades and walkways to the area">
 	
-	<CleanupOldModNames>
-		<Object name="Fortitude_Mod"/>
+	<CleanupOldModNames name="OldModNameCleanup" description="Fill this with an Object per old mod name you need to cleanup; 
+		although it isn't mandatory, it's nice because changing your mod name could potentially break the files">
+		<Objects>
+			<Object name="Fortitude_Mod"/>
+		</Objects>
 	</CleanupOldModNames>
 	
 	<FacilitiesData>

--- a/XmlMods/TemplatesAndExamples/FortitudeMod - Bases - Snyder.xml
+++ b/XmlMods/TemplatesAndExamples/FortitudeMod - Bases - Snyder.xml
@@ -2,6 +2,10 @@
 <!DOCTYPE xml>
 <ModData mod_name="Fortitude_Mod-Bases-Snyder_Trucking_Warehouse" mod_author="phacops" mod_description="When moving into the Snyder Trucking Warehouse, this adds barricades and blockades and walkways to the area">
 	
+	<CleanupOldModNames>
+		<Object name="Fortitude_Mod"/>
+	</CleanupOldModNames>
+	
 	<FacilitiesData>
 		<Objects name="Snyder_Objects" mod_segment="Snyder Trucking Warehouse" parent_tag="Prefab" parent_name="warehouse.workshop">
 			<Object Type="Brush" Name="Core_Geometry_Container" Pos="0,0,20" FloorNumber="-1" Rotate="1,0,0,0" ColorRGB="16777215" MatLayersMask="0" Prefab="objects/Fortitude/snyder.cgf" NoCollision="0" OutdoorOnly="0" CastShadowMaps="1" RainOccluder="1" SupportSecondVisarea="0" Hideable="0" LodRatio="100" ViewDistRatio="200" MeshIntegrationType="0" NotTriangulate="0" AIRadius="-1" NoStaticDecals="0" NoAmnbShadowCaster="0" RecvWind="0" AllowInteractionMarkup="0" RndFlags="536870920"/>

--- a/XmlMods/TemplatesAndExamples/FortitudeMod - Bases - Snyder.xml
+++ b/XmlMods/TemplatesAndExamples/FortitudeMod - Bases - Snyder.xml
@@ -1,21 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE xml>
-<ModData mod_name="Fortitude_Mod-Bases-Snyder_Trucking_Warehouse" mod_author="phacops" mod_description="When moving into the Snyder Trucking Warehouse, this adds barricades and blockades and walkways to the area">
-	
-	<CleanupOldModNames name="OldModNameCleanup" description="Fill this with an Object per old mod name you need to cleanup; 
-		although it isn't mandatory, it's nice because changing your mod name could potentially break the files">
-		<Objects>
-			<Object name="Fortitude_Mod"/>
-		</Objects>
-	</CleanupOldModNames>
+<ModData mod_name="Fortitude_Mod" mod_segment="Bases - Snyder_Trucking_Warehouse" mod_author="phacops" 
+	mod_description="When moving into the Snyder Trucking Warehouse, this adds barricades and blockades and walkways to the area">
 	
 	<FacilitiesData>
-		<Objects name="Snyder_Objects" mod_segment="Snyder Trucking Warehouse" parent_tag="Prefab" parent_name="warehouse.workshop">
-			<Object Type="Brush" Name="Core_Geometry_Container" Pos="0,0,20" FloorNumber="-1" Rotate="1,0,0,0" ColorRGB="16777215" MatLayersMask="0" Prefab="objects/Fortitude/snyder.cgf" NoCollision="0" OutdoorOnly="0" CastShadowMaps="1" RainOccluder="1" SupportSecondVisarea="0" Hideable="0" LodRatio="100" ViewDistRatio="200" MeshIntegrationType="0" NotTriangulate="0" AIRadius="-1" NoStaticDecals="0" NoAmnbShadowCaster="0" RecvWind="0" AllowInteractionMarkup="0" RndFlags="536870920"/>
-			<Object Type="Brush" Name="VehicleBeingStrippedOnLift" Pos="2.5,-2.5,0" FloorNumber="-1" Rotate="0.383,0,0,-0.924" ColorRGB="16777215" MatLayersMask="0" Prefab="objects/vehicles/musclecar/musclecar.cga" NoCollision="0" OutdoorOnly="0" CastShadowMaps="1" RainOccluder="1" SupportSecondVisarea="0" Hideable="0" LodRatio="100" ViewDistRatio="200" MeshIntegrationType="0" NotTriangulate="0" AIRadius="-1" NoStaticDecals="0" NoAmnbShadowCaster="0" RecvWind="0" AllowInteractionMarkup="1" RndFlags="536870920"/>
-			<Object Type="Brush" Name="Truck1" Pos="49.13483,-7.83943,1.5" FloorNumber="-1" Rotate="-0.655,0.282,0.648,0.266" ColorRGB="16777215" MatLayersMask="0" Prefab="objects/decor/industrial/truck_trailer/truck_trailer_01.cgf" NoCollision="0" OutdoorOnly="0" CastShadowMaps="1" RainOccluder="1" SupportSecondVisarea="0" Hideable="0" LodRatio="100" ViewDistRatio="200" MeshIntegrationType="0" NotTriangulate="0" AIRadius="-1" NoStaticDecals="0" NoAmnbShadowCaster="0" RecvWind="0" AllowInteractionMarkup="1" RndFlags="536870920"/>
-			<Object Type="Brush" Name="Truck2" Pos="43.26796,-25.08663,0" FloorNumber="-1" Rotate="0.359,0,0,0.933" ColorRGB="16777215" MatLayersMask="0" Prefab="objects/decor/industrial/truck_trailer/truck_trailer_01.cgf" NoCollision="0" OutdoorOnly="0" CastShadowMaps="1" RainOccluder="1" SupportSecondVisarea="0" Hideable="0" LodRatio="100" ViewDistRatio="200" MeshIntegrationType="0" NotTriangulate="0" AIRadius="-1" NoStaticDecals="0" NoAmnbShadowCaster="0" RecvWind="0" AllowInteractionMarkup="1" RndFlags="536870920"/>
-			<Object Type="Brush" Name="Truck3" Pos="24.86065,-44.2547,1.29537" FloorNumber="-1" Rotate="0.306,0.638,-0.299,0.64" ColorRGB="16777215" MatLayersMask="0" Prefab="objects/decor/industrial/truck_trailer/truck_trailer_01.cgf" NoCollision="0" OutdoorOnly="0" CastShadowMaps="1" RainOccluder="1" SupportSecondVisarea="0" Hideable="0" LodRatio="100" ViewDistRatio="200" MeshIntegrationType="0" NotTriangulate="0" AIRadius="-1" NoStaticDecals="0" NoAmnbShadowCaster="0" RecvWind="0" AllowInteractionMarkup="1" RndFlags="536870920"/>
+		<Objects name="Snyder_Objects" mod_subsegment="Snyder Trucking Warehouse" parent_tag="Prefab" parent_name="warehouse.workshop">
+		
+			<Object Type="Brush" Name="Core_Geometry_Container" Pos="0,0,0" FloorNumber="-1" Rotate="1,0,0,0" ColorRGB="16777215" MatLayersMask="0" 
+				Prefab="objects/Fortitude/snyder.cgf" NoCollision="0" OutdoorOnly="0" CastShadowMaps="1" RainOccluder="1" SupportSecondVisarea="0" 
+				Hideable="0" LodRatio="100" ViewDistRatio="200" MeshIntegrationType="0" NotTriangulate="0" AIRadius="-1" NoStaticDecals="0" NoAmnbShadowCaster="0" 
+				RecvWind="0" AllowInteractionMarkup="0" RndFlags="536870920"/>
+				
+			<Object Type="Brush" Name="VehicleBeingStrippedOnLift" Pos="2.5,-2.5,0" FloorNumber="-1" Rotate="0.383,0,0,-0.924" ColorRGB="16777215" MatLayersMask="0" 
+				Prefab="objects/vehicles/musclecar/musclecar.cga" NoCollision="0" OutdoorOnly="0" CastShadowMaps="1" RainOccluder="1" SupportSecondVisarea="0" 
+				Hideable="0" LodRatio="100" ViewDistRatio="200" MeshIntegrationType="0" NotTriangulate="0" AIRadius="-1" NoStaticDecals="0" NoAmnbShadowCaster="0" 
+				RecvWind="0" AllowInteractionMarkup="1" RndFlags="536870920"/>
+				
+			<Object Type="Brush" Name="Truck1" Pos="49.13483,-7.83943,1.5" FloorNumber="-1" Rotate="-0.655,0.282,0.648,0.266" ColorRGB="16777215" MatLayersMask="0" 
+				Prefab="objects/decor/industrial/truck_trailer/truck_trailer_01.cgf" NoCollision="0" OutdoorOnly="0" CastShadowMaps="1" RainOccluder="1" SupportSecondVisarea="0" 
+				Hideable="0" LodRatio="100" ViewDistRatio="200" MeshIntegrationType="0" NotTriangulate="0" AIRadius="-1" NoStaticDecals="0" NoAmnbShadowCaster="0" 
+				RecvWind="0" AllowInteractionMarkup="1" RndFlags="536870920"/>
+				
+			<Object Type="Brush" Name="Truck2" Pos="43.26796,-25.08663,0" FloorNumber="-1" Rotate="0.359,0,0,0.933" ColorRGB="16777215" MatLayersMask="0" 
+				Prefab="objects/decor/industrial/truck_trailer/truck_trailer_01.cgf" NoCollision="0" OutdoorOnly="0" CastShadowMaps="1" RainOccluder="1" SupportSecondVisarea="0" 
+				Hideable="0" LodRatio="100" ViewDistRatio="200" MeshIntegrationType="0" NotTriangulate="0" AIRadius="-1" NoStaticDecals="0" NoAmnbShadowCaster="0" 
+				RecvWind="0" AllowInteractionMarkup="1" RndFlags="536870920"/>
+				
+			<Object Type="Brush" Name="Truck3" Pos="24.86065,-44.2547,1.29537" FloorNumber="-1" Rotate="0.306,0.638,-0.299,0.64" ColorRGB="16777215" MatLayersMask="0"
+				 Prefab="objects/decor/industrial/truck_trailer/truck_trailer_01.cgf" NoCollision="0" OutdoorOnly="0" CastShadowMaps="1" RainOccluder="1" SupportSecondVisarea="0" 
+				 Hideable="0" LodRatio="100" ViewDistRatio="200" MeshIntegrationType="0" NotTriangulate="0" AIRadius="-1" NoStaticDecals="0" NoAmnbShadowCaster="0" 
+				 RecvWind="0" AllowInteractionMarkup="1" RndFlags="536870920"/>
+				 
 		</Objects>
 	</FacilitiesData>
 	

--- a/XmlMods/TemplatesAndExamples/Instructions - ModXML.xml
+++ b/XmlMods/TemplatesAndExamples/Instructions - ModXML.xml
@@ -9,22 +9,41 @@ mod_description - A short paragraph or two about what your mod does,
 	which will later be funneled into a description region for users to decide whether to enable or disable, 
 	For now, it just lets us have an understanding of what the end effect of this file should be.
 -->
-<ModData mod_name="NAME_OF_MOD" mod_author="AUTHOR_OF_MOD" mod_description="DESCRIPTION_OF_MOD">
+<ModData mod_name="NAME_OF_MOD" mod_segment="DIVISION_OF_MOD_IF_ANY" mod_author="AUTHOR_OF_MOD" mod_description="DESCRIPTION_OF_MOD">
 
+	<!--  For cleaning up the old names of your mod, if you change it - ignore if this isn't the case 
+		Will cleanup any element in a game file with the mod_name you add in as an Object. 
+		Fill this with an Object per old mod name you need to cleanup; 
+		although it isn't mandatory, it's nice because changing your mod name could potentially break the files -->
+	<CleanupOldModNames name="OldModNameCleanup">
+		<Objects>
+		
+			<Object Mod_Name="OLD_MOD_NAME_TO_DESTROY_ELEMENTS_FOR"/>
+			
+		</Objects>
+	</CleanupOldModNames>
 	<!-- Anything that needs to be added to the Mission_Mission0.xml needs a sub-object placed here.
 		Note that the only time this should happen is things like Entities, or Time of Day changes 
-			(a feature which is uncommon so I'll handle that later)-->
+			(a feature which is uncommon so I'll handle that later)
+			
+			parent_tag should always be Objects; could make this explicit in code, 
+			but this seemed more instructive to modders in terms of XML construction
+			-->
 	<MissionData>
-		<Objects name="NAME_Entities" mod_segment="SEGMENT_NAME" parent_tag="Objects">
+		<Objects name="NAME_Entities" mod_subsegment="SEGMENT_NAME" parent_tag="Objects">
+		
 			<Object Name="UNIQUE_NAME"/>
+			
 		</Objects>
 		
 		<!-- Example - No need to add multiple Objects here, because the Mission file just dumps everything in one bucket
 			Note: Mission_Mission0.xml items can be of many element types - 
 				but Mission can also have <Object> containers, such as decals -->
-		<Objects name="Savini_Entities" mod_segment="Savini/Riverside" parent_tag="Objects">
+		<Objects name="Savini_Entities" mod_subsegment="Savini/Riverside" parent_tag="Objects">
+		
 			<!-- Don't try to use this in a real mod - I chopped it up so it was a clearer example ;) -->
 			<Entity Name="SaviniEntity" Pos="1501.3844,800.42261,101.17547" EntityClass="SurveyPoint" EntityId="4370" EntityGuid="403D4E79B3B28330"/>
+			
 		</Objects>
 	</MissionData>
 	
@@ -40,10 +59,12 @@ mod_description - A short paragraph or two about what your mod does,
 		Note: All child entries of <Objects> for <FacilitiesData> (Prefabs, Facilities.xml file), 
 		should be of the element type <Object>.
 		-->
-		<Objects name="LOCATION_Objects" mod_segment="SEGMENT_NAME" parent_tag="ELEMENT_TYPE_TO_ADD_THIS_TO" 
+		<Objects name="LOCATION_Objects" mod_subsegment="SEGMENT_NAME" parent_tag="ELEMENT_TYPE_TO_ADD_THIS_TO" 
 			parent_name="ELEMENT_NAME_TO_ADD_THIS_TO">
+			
 			<!-- When adding an Object, note that the manager will apply your mod_name, as the last XML attribute, your mod_name -->
 			<Object Type="Brush" Name="UNIQUE_NAME" />
+			
 		</Objects>
 		
 		<!-- Example - 
@@ -58,17 +79,22 @@ mod_description - A short paragraph or two about what your mod does,
 			
 			E.g. for Snyder, you'll move in and you won't see these truck trailers until you cleanup the workshop.
 			-->
-		<Objects name="Savini_Objects" mod_segment="Savini/Riverside" parent_tag="Prefab" parent_name="riverside.command_center">
+		<Objects name="Savini_Objects" mod_subsegment="Savini/Riverside" parent_tag="Prefab" parent_name="riverside.command_center">
+		
 			<Object Type="Brush" Name="Savini_Fortitude" Pos="2.5,-2.5,0" FloorNumber="-1" Rotate="0.383,0,0,-0.924" ColorRGB="16777215" MatLayersMask="0" 
 				Prefab="objects/vehicles/musclecar/musclecar.cga" NoCollision="0" OutdoorOnly="0" CastShadowMaps="1" RainOccluder="1" 
 				SupportSecondVisarea="0" Hideable="0" LodRatio="100" ViewDistRatio="200" MeshIntegrationType="0" NotTriangulate="0" 
 				AIRadius="-1" NoStaticDecals="0" NoAmnbShadowCaster="0" RecvWind="0" AllowInteractionMarkup="1" RndFlags="536870920"/>
+				
 		</Objects>
-		<Objects name="Snyder_Objects" mod_segment="Snyder Trucking Warehouse" parent_tag="Prefab" parent_name="warehouse.workshop">
+		<Objects name="Snyder_Objects" mod_subsegment="Snyder Trucking Warehouse" parent_tag="Prefab" parent_name="warehouse.workshop">
+		
 			<Object Type="Brush" Name="Snyder_Fortitude-Truck2" Pos="43.26796,-25.08663,0" FloorNumber="-1" Rotate="0.359,0,0,0.933" 
 				ColorRGB="16777215" MatLayersMask="0" Prefab="objects/decor/industrial/truck_trailer/truck_trailer_01.cgf" />
+				
 			<Object Type="Brush" Name="Snyder_Fortitude-Truck3" Pos="32.05709,-33.00128,1.50468" FloorNumber="-1" Rotate="0.247,0.666,-0.239,0.662" 
 				ColorRGB="16777215" MatLayersMask="0" Prefab="objects/decor/industrial/truck_trailer/truck_trailer_01.cgf"/>
+				
 		</Objects>
 	</FacilitiesData>
 	

--- a/src/main/java/ModChangeObjectContainer.java
+++ b/src/main/java/ModChangeObjectContainer.java
@@ -36,7 +36,12 @@ public class ModChangeObjectContainer {
 		this.modSegment = containerElement.valueOf("@mod_segment");
 		this.parentTag = containerElement.valueOf("@parent_tag");
 		this.parentName = containerElement.valueOf("@parent_name");
-		this.childElements = containerElement.selectNodes("//Objects[@name='" + this.name + "']/descendant::*");
+		
+		if (fileToMod.equals("CleanupOldModNames")) {
+			this.childElements = containerElement.selectNodes("//Objects/descendant::*");
+		} else {
+			this.childElements = containerElement.selectNodes("//Objects[@name='" + this.name + "']/descendant::*");
+		}
 	}
 	
 	public String getModName() {

--- a/src/main/java/ModChangeObjectContainer.java
+++ b/src/main/java/ModChangeObjectContainer.java
@@ -21,7 +21,7 @@ public class ModChangeObjectContainer {
 	String modAuthor;
 	String fileToMod;
 	String name;
-	String modSegment;
+	String modSubSegment;
 	String parentTag;
 	String parentName;
 	
@@ -33,7 +33,7 @@ public class ModChangeObjectContainer {
 		this.modAuthor = modAuthor;
 		this.fileToMod = fileToMod;
 		this.name = containerElement.valueOf("@name");
-		this.modSegment = containerElement.valueOf("@mod_segment");
+		this.modSubSegment = containerElement.valueOf("@mod_subsegment");
 		this.parentTag = containerElement.valueOf("@parent_tag");
 		this.parentName = containerElement.valueOf("@parent_name");
 		
@@ -60,8 +60,8 @@ public class ModChangeObjectContainer {
 		return name;
 	}
 
-	public String getModSegment() {
-		return modSegment;
+	public String getModSubSegment() {
+		return modSubSegment;
 	}
 
 	public String getParentTag() {
@@ -79,9 +79,9 @@ public class ModChangeObjectContainer {
 	@Override
 	public String toString() {
 		
-		return this.modSegment + "\n"
+		return this.modSubSegment + "\n"
 				+ "name: " + this.name + "\n"
-				+ "modSegment: " + this.modSegment + "\n"
+				+ "modSegment: " + this.modSubSegment + "\n"
 				+ "fileToMod: " + this.fileToMod + "\n"
 				+ "parentTag: " + this.parentTag + "\n"
 				+ "parentName: " + this.parentName + "\n"

--- a/src/main/java/ModXML.java
+++ b/src/main/java/ModXML.java
@@ -43,11 +43,14 @@ public class ModXML {
 	}
 	
 	/**
-	 * Build the objects separately for facilities and mission
+	 * Build the objects separately for cleanup, facilities, and mission
+	 * Note: Any new elements must be set here explicitly - 
+	 * just an attempt at greater integrity by not parsing unwanted code
 	 */
 	private void setModObjects () {
-		setModFacilityObjects();
+		setModCleanupObjects();
 		setModMissionObjects();
+		setModFacilityObjects();
 	}
 	
 	/**
@@ -76,6 +79,23 @@ public class ModXML {
 		for (Node objectsChild : facilitiesElements) {
 			System.out.println("[" + this.modName + "] - [" + objectsChild.getPath() + "]");
 			modObjects.add(new ModChangeObjectContainer(this.modName, this.modAuthor, "FacilitiesData", objectsChild));
+		}
+	}
+	
+	/**
+	 * Create cleanup-related objects and add them to our list of all objects
+	 * These will be iterated for destroying deprecated elements in the game files before applying the new
+	 * This is only if a mod changes names during the course of development, 
+	 * otherwise all elements are naturally destroyed before applying the mod.
+	 */
+	private void setModCleanupObjects () {
+		@SuppressWarnings("unchecked")
+		List<Element> cleanupElements = this.modXmlFileDOM.selectNodes("//ModData/CleanupOldModNames/Objects");
+		System.out.println("\nNumber of Cleanup Elements in " + this.modName + " - [" + cleanupElements.size() + "]");
+		
+		for (Node objectsChild : cleanupElements) {
+			System.out.println("[" + this.modName + "] - [" + objectsChild.getPath() + "]");
+			modObjects.add(new ModChangeObjectContainer(this.modName, this.modAuthor, "CleanupOldModNames", objectsChild));
 		}
 	}
 	

--- a/src/main/java/ModXML.java
+++ b/src/main/java/ModXML.java
@@ -21,6 +21,7 @@ public class ModXML {
 	
 	Document modXmlFileDOM;
 	String modName;
+	String modSegment;
 	String modAuthor;
 	List<ModChangeObjectContainer> modObjects = new ArrayList<>();
 	
@@ -32,6 +33,7 @@ public class ModXML {
 	public ModXML (Document modDom) {
 		this.modXmlFileDOM = modDom;
 		this.modName = modDom.selectSingleNode("ModData").valueOf("@mod_name");
+		this.modSegment = modDom.selectSingleNode("ModData").valueOf("@mod_segment");
 		this.modAuthor = modDom.selectSingleNode("ModData").valueOf("@mod_author");
 		setModObjects();
 	}
@@ -107,5 +109,17 @@ public class ModXML {
 	 */
 	public List<ModChangeObjectContainer> getModObjects () {
 		return this.modObjects;
+	}
+	
+	public String getModName() {
+		return this.modName;
+	}
+	
+	public String getModSegment() {
+		return this.modSegment;
+	}
+	
+	public String getModAuthor() {
+		return this.modAuthor;
 	}
 }

--- a/src/test/java/TestModConstructionAndHandling.java
+++ b/src/test/java/TestModConstructionAndHandling.java
@@ -10,12 +10,13 @@ import org.testng.annotations.Test;
  * @author Phacops
  */
 public class TestModConstructionAndHandling extends LoggingHelper {
-	ModXMLHelper modXMLHelper = new ModXMLHelper();
-	ModFileUtil modFileUtil = new ModFileUtil();
+	private ModXMLHelper modXMLHelper = new ModXMLHelper();
+	private ModFileUtil modFileUtil = new ModFileUtil();
 	
-	String modTestXMLFileTarget = "src/test/resources/FortitudeModTestXML.xml";
-	String facilitiesTestXMLFileTarget = "src/test/resources/TestFacilitiesXML.xml";
-	String missionTestXMLFileTarget = "src/test/resources/TestMissionXML.xml";
+	private String modTestXMLFileTarget = "src/test/resources/FortitudeModTestXML.xml";
+	private String facilitiesTestXMLFileTarget = "src/test/resources/TestFacilitiesXML.xml";
+	private String missionTestXMLFileTarget = "src/test/resources/TestMissionXML.xml";
+	private String modTestCleanupXMLFileTarget = "src/test/resources/FortitudeModTestCleanup.xml";
 	
 	@Test (description = "Test XML element insertion")
 	public void testFullHandling () {
@@ -86,7 +87,7 @@ public class TestModConstructionAndHandling extends LoggingHelper {
 			Assert.assertEquals(item1.getName(), "Snyder_Objects");
 			
 			AND("Confirming the parsed mod_segment matches the actual XML...");
-			Assert.assertEquals(item1.getModSegment(), "Snyder Trucking Warehouse");
+			Assert.assertEquals(item1.getModSubSegment(), "Snyder Trucking Warehouse");
 			
 			AND("Confirming the parsed File to Mod matches the actual XML's <FacilitiesData> wrapper...");
 			Assert.assertEquals(item1.getFileToMod(), "FacilitiesData");
@@ -100,6 +101,33 @@ public class TestModConstructionAndHandling extends LoggingHelper {
 			LASTLY("Confirming the parsed child element count matches the actual XML...");
 			Assert.assertEquals(item1.getChildElements().size(), 1);
 			
+		} catch (Exception e) {
+			e.printStackTrace();
+			Assert.fail("Failed to insert elements into XML, error was: \n" + e.getMessage());
+		}
+	}
+	
+	@Test (description = "Test XML cleanup of old mod names")
+	public void testOldModNameCleanupFromXMLs () {
+		SCENARIO("Test finding old mod names and correctly eliminating them from the XMLs, "
+				+ "which would be done prior to adding any new changes");
+		try {
+			FIRST("Building a basic test XML into the ModXML we want to parse.");
+			List<ModXML> modList = new ArrayList<ModXML>();
+			modList.add(new ModXML(modFileUtil.getXmlFileAndBuild(modTestCleanupXMLFileTarget)));
+			modXMLHelper.setModXMLs(modList);
+			
+			GIVEN("ModXML has been set...");
+			THEN("Setting the test Facilities XML");
+			modFileUtil.setFacilitiesXMLTarget(facilitiesTestXMLFileTarget);
+			AND("Setting the test Mission XML");
+			modFileUtil.setMissionXMLTarget(missionTestXMLFileTarget);
+			
+			THEN("Attempting to handle all actions "
+					+ "including capacity to cleanup mod elements with differing names");
+			modXMLHelper.handleModXMLFiles();
+			GIVEN("This was able to print");
+			THEN("We were able to successfully handle all mods without an exception.");
 		} catch (Exception e) {
 			e.printStackTrace();
 			Assert.fail("Failed to insert elements into XML, error was: \n" + e.getMessage());

--- a/src/test/java/TestXMLHandling.java
+++ b/src/test/java/TestXMLHandling.java
@@ -21,6 +21,8 @@ public class TestXMLHandling extends LoggingHelper {
 		}
 	}
 	
+	//TODO - Add more microscopic testing for checking that elements have been correctly cleaned up by the cleanup operation
+	
 	@Test (description = "Test XML element removal")
 	public void testRemoveElementsFromXMLDOM () {
 		try {

--- a/src/test/resources/FortitudeModTestCleanup.xml
+++ b/src/test/resources/FortitudeModTestCleanup.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
+<ModData mod_name="TestCleanup" mod_author="phacops" mod_description="Test cleaning up an old mod name">
+	
+	<CleanupOldModNames name="OldModNameCleanup" description="Fill this with an Object per old mod name you need to cleanup; 
+		although it isn't mandatory, it's nice because changing your mod name could potentially break the files">
+		<Objects>
+			<Object name="Fortitude_Mod"/>
+		</Objects>
+	</CleanupOldModNames>
+</ModData>

--- a/src/test/resources/FortitudeModTestCleanup.xml
+++ b/src/test/resources/FortitudeModTestCleanup.xml
@@ -1,11 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE xml>
-<ModData mod_name="TestCleanup" mod_author="phacops" mod_description="Test cleaning up an old mod name">
+<ModData mod_name="Fortitude_Mod" mod_segment="Cleanup testing" mod_author="phacops" mod_description="Test cleaning up an old mod name">
 	
 	<CleanupOldModNames name="OldModNameCleanup" description="Fill this with an Object per old mod name you need to cleanup; 
 		although it isn't mandatory, it's nice because changing your mod name could potentially break the files">
 		<Objects>
-			<Object name="Fortitude_Mod"/>
+		
+			<Object Mod_Name="Deprecated_Mod_Name"/>
+		
 		</Objects>
 	</CleanupOldModNames>
+	
+	<MissionData>
+		<Objects name="Savini_Entities" mod_subsegment="Savini/Riverside" parent_tag="Objects">
+		
+			<Object ADoesNotBelongInFacilities="true" Name="SaviniEntity" Pos="1501.3844,800.42261,101.17547" 
+				EntityClass="SurveyPoint" EntityId="4370" EntityGuid="403D4E79B3B28330"/>
+		
+		</Objects>
+	</MissionData>
+	
 </ModData>

--- a/src/test/resources/FortitudeModTestXML.xml
+++ b/src/test/resources/FortitudeModTestXML.xml
@@ -1,20 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE xml>
-<ModData mod_name="Fortitude_Mod" mod_author="phacops">
+<ModData mod_name="Fortitude_Mod" mod_segment="Test Mod handling via Pseudo-changes to Bases" 
+	mod_author="phacops" mod_description="Test XML for requesting mod additions">
+
 	<FacilitiesData>
-		<Objects name="Snyder_Objects" mod_segment="Snyder Trucking Warehouse" parent_tag="Prefab" parent_name="warehouse.workshop">
-			<Object ADoesNotBelongInMission="true" Type="Brush" Name="Snyder_Fortitude" Pos="2.5,-2.5,0" FloorNumber="-1" Rotate="0.383,0,0,-0.924" ColorRGB="16777215" MatLayersMask="0" Prefab="objects/vehicles/bubblecar/bubblecar.cga" NoCollision="0" OutdoorOnly="0" CastShadowMaps="1" RainOccluder="1" SupportSecondVisarea="0" Hideable="0" LodRatio="100" ViewDistRatio="200" MeshIntegrationType="0" NotTriangulate="0" AIRadius="-1" NoStaticDecals="0" NoAmnbShadowCaster="0" RecvWind="0" AllowInteractionMarkup="1" RndFlags="536870920"/>
+		<Objects name="Snyder_Objects" mod_subsegment="Snyder Trucking Warehouse" parent_tag="Prefab" parent_name="warehouse.workshop">
+		
+			<Object ADoesNotBelongInMission="true" Type="Brush" Name="Snyder_Fortitude" Pos="2.5,-2.5,0" FloorNumber="-1" Rotate="0.383,0,0,-0.924" 
+				ColorRGB="16777215" MatLayersMask="0" Prefab="objects/vehicles/bubblecar/bubblecar.cga" NoCollision="0" OutdoorOnly="0" CastShadowMaps="1"/>
+				
 		</Objects>
 		
-		<Objects name="Savini_Objects" mod_segment="Savini/Riverside" parent_tag="Prefab" parent_name="riverside.command_center">
-			<Object ADoesNotBelongInMission="true" Type="Brush" Name="Savini_Fortitude" Pos="2.5,-2.5,0" FloorNumber="-1" Rotate="0.383,0,0,-0.924" ColorRGB="16777215" MatLayersMask="0" Prefab="objects/vehicles/musclecar/musclecar.cga"/>
+		<Objects name="Savini_Objects" mod_subsegment="Savini/Riverside" parent_tag="Prefab" parent_name="riverside.command_center">
+		
+			<Object ADoesNotBelongInMission="true" Type="Brush" Name="Savini_Fortitude" Pos="2.5,-2.5,0" FloorNumber="-1" Rotate="0.383,0,0,-0.924" 
+				ColorRGB="16777215" MatLayersMask="0" Prefab="objects/vehicles/musclecar/musclecar.cga"/>
+				
 		</Objects>
 	</FacilitiesData>
 	
 	
 	<MissionData>
-		<Objects name="Savini_Entities" mod_segment="Savini/Riverside" parent_tag="Objects">
-			<Object ADoesNotBelongInFacilities="true" Name="SaviniEntity" Pos="1501.3844,800.42261,101.17547" EntityClass="SurveyPoint" EntityId="4370" EntityGuid="403D4E79B3B28330"/>
+		<Objects name="Savini_Entities" mod_subsegment="Savini/Riverside" parent_tag="Objects">
+		
+			<Object ADoesNotBelongInFacilities="true" Name="SaviniEntity" Pos="1501.3844,800.42261,101.17547" 
+				EntityClass="SurveyPoint" EntityId="4370" EntityGuid="403D4E79B3B28330"/>
+				
 		</Objects>
 	</MissionData>
+	
 </ModData>

--- a/src/test/resources/TestFacilitiesXML.xml
+++ b/src/test/resources/TestFacilitiesXML.xml
@@ -8,8 +8,9 @@
 			<Object Type="Brush" Layer="W layer" LayerGUID="{94243B821E98}" Id="{09E4E2F11AAE}" Name="folding_chair26" Pos="2.8345947,-12.219727,0.028869629" FloorNumber="-1" Rotate="-0.2756373,0,0,0.96126169" ColorRGB="16777215" MatLayersMask="0" Prefab="objects/decor/chairs/folding/folding_chair.cgf" NoCollision="0" OutdoorOnly="0" CastShadowMaps="1" RainOccluder="1" SupportSecondVisarea="0" Hideable="0" LodRatio="100" ViewDistRatio="100" MeshIntegrationType="0" NotTriangulate="0" AIRadius="-1" NoStaticDecals="0" NoAmnbShadowCaster="0" RecvWind="0" AllowInteractionMarkup="1" RndFlags="536870920"/>
    			<Object Type="Brush" Layer="W layer" LayerGUID="{94243B821E98}" Id="{13D248114F64}" Name="search_ground27" Pos="-1.5465088,1.5241089,0.040306091" FloorNumber="-1" Rotate="0.88294762,0,0,-0.46947151" ColorRGB="16777215" MatLayersMask="0" Prefab="objects/gameplay/facility_interaction/search_ground/search_ground.cgf" NoCollision="0" OutdoorOnly="0" CastShadowMaps="1" RainOccluder="1" SupportSecondVisarea="0" Hideable="0" LodRatio="100" ViewDistRatio="100" MeshIntegrationType="0" NotTriangulate="0" AIRadius="-1" NoStaticDecals="0" NoAmnbShadowCaster="0" RecvWind="0" AllowInteractionMarkup="1" RndFlags="536870920"/>
 			
-			<!-- Confirm that this gets deleted based on mod-name, regardless of position in object -->
+			<!-- Confirm that these get deleted based on mod-name, regardless of position in object -->
 			<ModWrapper mod_name="Fortitude_Mod" placement="start_tag" />
+			<ModWrapper mod_name="Deprecated_Mod_Name" placement="start_tag" />
 		</Objects>
 	</Prefab>
 	


### PR DESCRIPTION
 Large-scale overhaul, in line with adding cleanup ability for elements + adds wide-angle unit test //TODO microscopics + make pretty the instructional files and the actualized xml from my mods to be wholly clear on intent and boilerplate segments + optimize some methods to be a bit cleaner

XmlMods/{}.xml & src/test/resources/{}.xml
* Enhance content and push in line with latest changes

ModChangeObjectContainer.java
* Shift to being labelled subsegment in container as the parent may actually be a subsegment of a wider mod group, e.g. a Mission_Mission0.xml change for a single base, which would be a subsegment of a base mod segment.
 * Could just be pedantics, though I believe that an effective hierarchy in your mod groups should lead to better experiences for end-users when they want to slim the active mods, right?
 * E.g. Maybe I like one of the bases the way it is, but I want to mod another, and then switch between them - then I should have a simple ability to do that by excluding that mod segment I don't want.

ModXML.java
* Add cleanup handling
* Add getters for some attributes
* Add mod_segment to allow attribution of being part of a larger group

ModXMLHelper.java
* Optimize some handling by shifting DOM acquisitions to start
* Additional state checks and handling
* Increase clarity

TestModConstructionAndHandling.java
* Add cleanup test

